### PR TITLE
Fix to not allow slash at slug and tag

### DIFF
--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -13,8 +13,12 @@ const isValidMetaData = (obj: Meta): boolean => {
 const isValidContentData = (contentList: Array<Content>): boolean => {
   const slugList: Array<string> = [];
   for (const content of contentList) {
-    const { title, text, slug } = content;
+    const { title, text, slug, tags } = content;
     if (!title || !text || !slug) return false;
+
+    if (hasIncludeSlash(slug)) return false;
+
+    if (tags && hasIncludeSlash(tags)) return false;
 
     slugList.push(slug);
   }
@@ -31,6 +35,8 @@ const hasDuplicateSlug = (slugList: Array<string>): boolean => {
   const slugSet = new Set(slugList);
   return slugSet.size !== slugList.length;
 };
+
+const hasIncludeSlash = (tags: string): boolean => tags.indexOf('/') !== -1;
 
 export const isValidData = (
   general: General,

--- a/test/utils/validate.test.ts
+++ b/test/utils/validate.test.ts
@@ -121,4 +121,80 @@ describe('isValidData', (): void => {
 
     expect(isValidData(general, meta, contentList)).toBeFalsy();
   });
+
+  test('Should return false, If data is invalid. (Case of content slug include slash)', (): void => {
+    const general: General = { title: 'test', description: 'test' };
+    const meta: Meta = {
+      siteUrl: 'test',
+      title: 'test',
+      description: 'test',
+      ogpImage: 'test',
+    };
+    const contentList: Array<Content> = [
+      {
+        title: 'test1',
+        text: 'test1',
+        slug: 'test1',
+      },
+      {
+        title: 'test2',
+        text: 'test2',
+        slug: 'te/st2',
+      },
+    ];
+
+    expect(isValidData(general, meta, contentList)).toBeFalsy();
+  });
+
+  test('Should return true, If all data is valid. (Include tags)', (): void => {
+    const general: General = { title: 'test', description: 'test' };
+    const meta: Meta = {
+      siteUrl: 'test',
+      title: 'test',
+      description: 'test',
+      ogpImage: 'test',
+    };
+    const contentList: Array<Content> = [
+      {
+        title: 'test1',
+        text: 'test1',
+        slug: 'test1',
+        tags: 'test, post',
+      },
+      {
+        title: 'test2',
+        text: 'test2',
+        slug: 'test2',
+        tags: 'test, post',
+      },
+    ];
+
+    expect(isValidData(general, meta, contentList)).toBeTruthy();
+  });
+
+  test('Should return false, If data is invalid. (Case of content tags include slash)', (): void => {
+    const general: General = { title: 'test', description: 'test' };
+    const meta: Meta = {
+      siteUrl: 'test',
+      title: 'test',
+      description: 'test',
+      ogpImage: 'test',
+    };
+    const contentList: Array<Content> = [
+      {
+        title: 'test1',
+        text: 'test1',
+        slug: 'test1',
+        tags: 'test, post',
+      },
+      {
+        title: 'test2',
+        text: 'test2',
+        slug: 'test2',
+        tags: 'test, po/st',
+      },
+    ];
+
+    expect(isValidData(general, meta, contentList)).toBeFalsy();
+  });
 });


### PR DESCRIPTION
Fix to not allow it, as it may cause errors or unintended behavior.